### PR TITLE
Fixed typos in lines 1011 and 1013

### DIFF
--- a/parse_process.ipynb
+++ b/parse_process.ipynb
@@ -1008,9 +1008,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This exercise demonstrates the processing chain from raw to processed data product using publically available code, raw data files and metadata. These data and additional dataproducts could be further assembled into a NetCDF, as is produced by OOINet. This was never necessary for data evaluation purposes and should not prevent scientists from validating the output of OOINet. The \"first-in-class\" review effort revealed all steps in the data product processing chain, which allowed the Data Team to diagnose the root cause of issues and work with the appropriate team to find a fix.\n",
+    "This exercise demonstrates the processing chain from raw to processed data product using publicly available code, raw data files and metadata. These data and additional data products could be further assembled into a NetCDF, as is produced by OOINet. This was never necessary for data evaluation purposes and should not prevent scientists from validating the output of OOINet. The \"first-in-class\" review effort revealed all steps in the data product processing chain, which allowed the Data Team to diagnose the root cause of issues and work with the appropriate team to find a fix.\n",
     "\n",
-    "Stream Engine (uFrame) can be considered an assembly engine that brings together raw data, parsers, algorithms and metadata on demand and in real-time to produce a final NetCDF file (asynchronously) or as a real-time JSON data response (synchronously). The Stream Engine code is available on GitHub, but was not used in this excersize, because it is not necessary to recreate the processing pipeline from raw, through parsed and finally processed data.\n",
+    "Stream Engine (uFrame) can be considered an assembly engine that brings together raw data, parsers, algorithms and metadata on demand and in real-time to produce a final NetCDF file (asynchronously) or as a real-time JSON data response (synchronously). The Stream Engine code is available on GitHub, but was not used in this exercise, because it is not necessary to recreate the processing pipeline from raw, through parsed and finally processed data.\n",
     "\n",
     "https://github.com/oceanobservatories/stream_engine"
    ]


### PR DESCRIPTION
Looks really good. 

You could get input from Smith or Pete Cable on  "how to import the entire ion-functions library, or call it after installation similar to mi-instrument".

Otherwise I have no suggestions. Other than this is a complicated process, and will likely require examples for other data types like WFP and mooring data, which have platform-specific log files.